### PR TITLE
* fix bug in input number calulation for MB3 (was assuning 4 inputs p…

### DIFF
--- a/L1Trigger/L1TMuon/data/omtf_config/hwToLogicLayer.xml
+++ b/L1Trigger/L1TMuon/data/omtf_config/hwToLogicLayer.xml
@@ -204,10 +204,10 @@
       <Layer iFirstInput="0" iLayer="7" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="8" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="9" nInputs="6"/>
-      <Layer iFirstInput="2" iLayer="10" nInputs="6"/>
-      <Layer iFirstInput="2" iLayer="11" nInputs="6"/>
-      <Layer iFirstInput="2" iLayer="12" nInputs="6"/>
-      <Layer iFirstInput="2" iLayer="13" nInputs="6"/>
+      <Layer iFirstInput="0" iLayer="10" nInputs="6"/>
+      <Layer iFirstInput="0" iLayer="11" nInputs="6"/>
+      <Layer iFirstInput="0" iLayer="12" nInputs="6"/>
+      <Layer iFirstInput="0" iLayer="13" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="14" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="15" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="16" nInputs="6"/>
@@ -264,10 +264,10 @@
       <Layer iFirstInput="6" iLayer="7" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="8" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="9" nInputs="6"/>
-      <Layer iFirstInput="6" iLayer="10" nInputs="6"/>
-      <Layer iFirstInput="6" iLayer="11" nInputs="6"/>
-      <Layer iFirstInput="6" iLayer="12" nInputs="6"/>
-      <Layer iFirstInput="6" iLayer="13" nInputs="6"/>
+      <Layer iFirstInput="4" iLayer="10" nInputs="6"/>
+      <Layer iFirstInput="4" iLayer="11" nInputs="6"/>
+      <Layer iFirstInput="4" iLayer="12" nInputs="6"/>
+      <Layer iFirstInput="4" iLayer="13" nInputs="6"/>
       <Layer iFirstInput="2" iLayer="14" nInputs="4"/>
       <Layer iFirstInput="6" iLayer="15" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="16" nInputs="6"/>

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFSorter.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFSorter.h
@@ -46,6 +46,14 @@ class OMTFSorter{
 
  private:
 
+  ///Check if the hit pattern of given OMTF candite is not on the list
+  ///of invalid hit patterns. Invalid hit patterns provode very little
+  ///to efficiency, but gives high contribution to rate.
+  ///Candidate with invalid hit patterns is assigned quality=0.
+  ///Currently the list of invalid patterns is hardcoded.
+  ///This has to be read from configuration.
+  bool checkHitPatternValidity(unsigned int hits);
+
   ///Find a candidate with best parameters for given GoldenPattern
   ///Sorting is made amongs candidates with different reference layers
   ///The output tuple contains (nHitsMax, pdfValMax, refPhi, refLayer, hitsWord, refEta)

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.cc
@@ -92,9 +92,7 @@ void L1TMuonOverlapTrackProducer::endJob(){
     myWriter->initialiseXMLDocument(fName);
     myOMTF->averagePatterns(1);
     myOMTF->averagePatterns(0);
-
     writeMergedGPs();
-
     fName = "GPs_4x.xml";
     myWriter->finaliseXMLDocument(fName);
   }
@@ -108,8 +106,8 @@ void L1TMuonOverlapTrackProducer::writeMergedGPs(){
   GoldenPattern *dummy = new GoldenPattern(Key(0,0,0));
   dummy->reset();
 
-  unsigned int iPtMin = 8;
-  Key aKey = Key(1, iPtMin,0);
+  unsigned int iPtMin = 9;
+  Key aKey = Key(2, iPtMin,0);
   while(myGPmap.find(aKey)!=myGPmap.end()){
 
     GoldenPattern *aGP1 = myGPmap.find(aKey)->second;
@@ -118,20 +116,20 @@ void L1TMuonOverlapTrackProducer::writeMergedGPs(){
     GoldenPattern *aGP4 = dummy;
 
     ++aKey.thePtCode;
-    while(myGPmap.find(aKey)==myGPmap.end() && aKey.thePtCode<=400) ++aKey.thePtCode;    
-    if(aKey.thePtCode<=400 && myGPmap.find(aKey)!=myGPmap.end()) aGP2 =  myGPmap.find(aKey)->second;
+    while(myGPmap.find(aKey)==myGPmap.end() && aKey.thePtCode<=401) ++aKey.thePtCode;    
+    if(aKey.thePtCode<=401 && myGPmap.find(aKey)!=myGPmap.end()) aGP2 =  myGPmap.find(aKey)->second;
 
     if(aKey.thePtCode>71){
       ++aKey.thePtCode;
-      while(myGPmap.find(aKey)==myGPmap.end() && aKey.thePtCode<=400) ++aKey.thePtCode;    
-      if(aKey.thePtCode<=400 && myGPmap.find(aKey)!=myGPmap.end()) aGP3 =  myGPmap.find(aKey)->second;
+      while(myGPmap.find(aKey)==myGPmap.end() && aKey.thePtCode<=401) ++aKey.thePtCode;    
+      if(aKey.thePtCode<=401 && myGPmap.find(aKey)!=myGPmap.end()) aGP3 =  myGPmap.find(aKey)->second;
 
       ++aKey.thePtCode;
-      while(myGPmap.find(aKey)==myGPmap.end() && aKey.thePtCode<=400) ++aKey.thePtCode;    
-      if(aKey.thePtCode<=400 && myGPmap.find(aKey)!=myGPmap.end()) aGP4 =  myGPmap.find(aKey)->second;
+      while(myGPmap.find(aKey)==myGPmap.end() && aKey.thePtCode<=401) ++aKey.thePtCode;    
+      if(aKey.thePtCode<=401 && myGPmap.find(aKey)!=myGPmap.end()) aGP4 =  myGPmap.find(aKey)->second;
     }
     ++aKey.thePtCode;
-    while(myGPmap.find(aKey)==myGPmap.end() && aKey.thePtCode<=400) ++aKey.thePtCode;    
+    while(myGPmap.find(aKey)==myGPmap.end() && aKey.thePtCode<=401) ++aKey.thePtCode;    
     myWriter->writeGPData(*aGP1,*aGP2, *aGP3, *aGP4);
 
     ///Write the opposite charge.

--- a/L1Trigger/L1TMuonOverlap/plugins/OMTFPatternMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/OMTFPatternMaker.cc
@@ -134,7 +134,7 @@ void OMTFPatternMaker::endJob(){
     myOMTFConfigMaker->printConnections(std::cout,iProcessor,3);
     myOMTFConfigMaker->printConnections(std::cout,iProcessor,4);
     myOMTFConfigMaker->printConnections(std::cout,iProcessor,5);
-    myOMTFConfigMaker->printConnections(std::cout,iProcessor,6);
+    //myOMTFConfigMaker->printConnections(std::cout,iProcessor,6);
 
     myWriter->writeConnectionsData(OMTFConfiguration::measurements4D);
     myWriter->finaliseXMLDocument(fName);

--- a/L1Trigger/L1TMuonOverlap/src/AngleConverter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/AngleConverter.cc
@@ -166,10 +166,11 @@ float AngleConverter::getGlobalPhi(unsigned int rawid, const RPCDigi & aDigi){
   const GlobalPoint gp = roll->toGlobal(lp);
   roll.release();
 
-  //float phi = gp.phi()/(2.0*M_PI);
-  //int iPhi = phi*OMTFConfiguration::nPhiBins;
+  float phi = gp.phi()/(2.0*M_PI);
+  int iPhi = phi*OMTFConfiguration::nPhiBins;
+  return iPhi;
 
-  return gp.phi();
+  //return gp.phi();
 }
 ///////////////////////////////////////
 ///////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/src/GoldenPattern.cc
+++ b/L1Trigger/L1TMuonOverlap/src/GoldenPattern.cc
@@ -168,7 +168,7 @@ void GoldenPattern::normalise(){
   for (unsigned int iRefLayer=0;iRefLayer<meanDistPhi[0].size();++iRefLayer){
     for (unsigned int iLayer=0;iLayer<meanDistPhi.size();++iLayer){   
       if(meanDistPhiCounts.size() && meanDistPhiCounts[iLayer][iRefLayer]){
-	if (meanDistPhiCounts[iLayer][iRefLayer]<1000) 	meanDistPhi[iLayer][iRefLayer] = 0;
+	if(meanDistPhiCounts[iLayer][iRefLayer]<1000) 	meanDistPhi[iLayer][iRefLayer] = 0;
 	else meanDistPhi[iLayer][iRefLayer] = rint((float)meanDistPhi[iLayer][iRefLayer]/meanDistPhiCounts[iLayer][iRefLayer]);      
       }
     }

--- a/L1Trigger/L1TMuonOverlap/src/OMTFProcessor.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFProcessor.cc
@@ -131,7 +131,7 @@ bool OMTFProcessor::addGP(GoldenPattern *aGP){
 ///////////////////////////////////////////////
 void  OMTFProcessor::averagePatterns(int charge){
 
-  Key aKey(1, 8, charge);
+  Key aKey(2, 9, charge);
 
   while(theGPs.find(aKey)!=theGPs.end()){
 
@@ -141,17 +141,17 @@ void  OMTFProcessor::averagePatterns(int charge){
     GoldenPattern *aGP4 = aGP1;
 
     ++aKey.thePtCode;
-    while(theGPs.find(aKey)==theGPs.end() && aKey.thePtCode<=400) ++aKey.thePtCode;    
-    if(aKey.thePtCode<=400 && theGPs.find(aKey)!=theGPs.end()) aGP2 =  theGPs.find(aKey)->second;
+    while(theGPs.find(aKey)==theGPs.end() && aKey.thePtCode<=401) ++aKey.thePtCode;    
+    if(aKey.thePtCode<=401 && theGPs.find(aKey)!=theGPs.end()) aGP2 =  theGPs.find(aKey)->second;
     
     if(aKey.thePtCode>71){
       ++aKey.thePtCode;
-      while(theGPs.find(aKey)==theGPs.end() && aKey.thePtCode<=400) ++aKey.thePtCode;    
-      if(aKey.thePtCode<=400 && theGPs.find(aKey)!=theGPs.end()) aGP3 =  theGPs.find(aKey)->second;
+      while(theGPs.find(aKey)==theGPs.end() && aKey.thePtCode<=401) ++aKey.thePtCode;    
+      if(aKey.thePtCode<=401 && theGPs.find(aKey)!=theGPs.end()) aGP3 =  theGPs.find(aKey)->second;
 
       ++aKey.thePtCode;
-      while(theGPs.find(aKey)==theGPs.end() && aKey.thePtCode<=400) ++aKey.thePtCode;    
-      if(aKey.thePtCode<=400 && theGPs.find(aKey)!=theGPs.end()) aGP4 =  theGPs.find(aKey)->second;
+      while(theGPs.find(aKey)==theGPs.end() && aKey.thePtCode<=401) ++aKey.thePtCode;    
+      if(aKey.thePtCode<=401 && theGPs.find(aKey)!=theGPs.end()) aGP4 =  theGPs.find(aKey)->second;
     }
     else{
       aGP3 = aGP1;
@@ -160,7 +160,7 @@ void  OMTFProcessor::averagePatterns(int charge){
     //HACK. Have to clean this up.
     ///Previously pt codeswere going by steps of 1, now this is not the case
     ++aKey.thePtCode;
-    while(theGPs.find(aKey)==theGPs.end() && aKey.thePtCode<=400) ++aKey.thePtCode;    
+    while(theGPs.find(aKey)==theGPs.end() && aKey.thePtCode<=401) ++aKey.thePtCode;    
     ///////////////////////////////
     
     
@@ -170,7 +170,7 @@ void  OMTFProcessor::averagePatterns(int charge){
     GoldenPattern::vector2D meanDistPhi2  = aGP2->getMeanDistPhi();
     GoldenPattern::vector2D meanDistPhi3  = aGP3->getMeanDistPhi();
     GoldenPattern::vector2D meanDistPhi4  = aGP4->getMeanDistPhi();
-    /*    
+    /*        
      std::cout<<"Key: "
 	     <<aGP1->key()
 	     <<" "<<aGP2->key()

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -215,6 +215,25 @@ l1t::RegionalMuonCand OMTFSorter::sortProcessor(const std::vector<OMTFProcessor:
 }
 ///////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////
+bool OMTFSorter::checkHitPatternValidity(unsigned int hits){
+
+  return true;
+
+  //This is a place holder.
+  ///Code goint into the official github should have this uncommented.
+  ///FIXME: read the list from configuration so this can be controlled at runtime.
+  /*
+  std::vector<unsigned int> badPatterns = {99840, 34304, 3075, 36928, 12300, 98816, 98944, 33408, 66688, 66176, 7171, 20528, 33856, 35840, 4156, 34880};
+
+  for(auto aHitPattern: badPatterns){
+    if(hits==aHitPattern) return false;
+  }
+
+  return true; 
+  */
+}
+///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////
 void OMTFSorter::sortProcessor(const std::vector<OMTFProcessor::resultsMap> & procResults,
 			       l1t::RegionalMuonCandBxCollection & sortedCands,
 			       int bx, int charge){
@@ -234,6 +253,8 @@ void OMTFSorter::sortProcessor(const std::vector<OMTFProcessor::resultsMap> & pr
     ///DT bending and position hit is counted as one.
     ///thus we subtract 1 for each DT station hit.
     candidate.setHwQual(bits.count() - bits.test(0) - bits.test(2) - bits.test(4));
+    ///Candidates with bad hit patterns get quality 0.
+    if(!checkHitPatternValidity(myCand.hits)) candidate.setHwQual(0);
     std::map<int, int> trackAddr;
     trackAddr[0] = myCand.hits;
     trackAddr[1] = myCand.refLayer;

--- a/L1Trigger/L1TMuonOverlap/test/expert/mergePatterns.py
+++ b/L1Trigger/L1TMuonOverlap/test/expert/mergePatterns.py
@@ -76,7 +76,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
-path = "../../job_3_pat/8_0_0/"
+path = "../../job_3_pat/8_0_0_15_12_2015/"
 patternsXMLFiles = cms.VPSet()
 for ipt in xrange(4,32):
     patternsXMLFiles.append(cms.PSet(patternsXMLFile = cms.FileInPath(path+"SingleMu_"+str(ipt)+"_p/GPs.xml")))

--- a/L1Trigger/L1TMuonOverlap/test/expert/runOMTFPatternMaker.py
+++ b/L1Trigger/L1TMuonOverlap/test/expert/runOMTFPatternMaker.py
@@ -63,23 +63,22 @@ process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 process.source = cms.Source(
     'PoolSource',
     #fileNames = cms.untracked.vstring('file:///afs/cern.ch/work/a/akalinow/CMS/OverlapTrackFinder/data/Crab/SingleMuFullEtaTestSample/720_FullEta_v1/data/SingleMu_16_p_1_2_TWz.root')
-    fileNames = cms.untracked.vstring('file:///home/akalinow/scratch/CMS/OverlapTrackFinder/data/Crab/SingleMuFullEta/721_FullEta_v4/data/SingleMu_25_p_133_2_QJ1.root')
+    fileNames = cms.untracked.vstring('file:///home/akalinow/scratch/CMS/OverlapTrackFinder/Crab/SingleMuFullEta/721_FullEta_v4/data/SingleMu_25_p_133_2_QJ1.root')
    
 )
-
 '''
 ##Use all available events in a single job.
 ##Only for making the connections maps.
 process.source.fileNames =  cms.untracked.vstring()
-path = "/afs/cern.ch/work/a/akalinow/CMS/OverlapTrackFinder/data/Crab/SingleMuFullEta/721_FullEta_v4/data/"
-command = "ls "+path+"/SingleMu_25_?_*"
+path = "/home/akalinow/scratch/CMS/OverlapTrackFinder/Crab/SingleMuFullEta/721_FullEta_v4/data/"
+command = "ls "+path+"/SingleMu_10_?_*"
 fileList = commands.getoutput(command).split("\n")
 process.source.fileNames =  cms.untracked.vstring()
 for aFile in fileList:
     process.source.fileNames.append('file:'+aFile)
 '''
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000000))
 
 ###TEST
 '''
@@ -124,7 +123,7 @@ process.omtfPatternMaker = cms.EDAnalyzer("OMTFPatternMaker",
                                           dropDTPrimitives = cms.bool(False),                                    
                                           dropCSCPrimitives = cms.bool(False),   
                                           ptCode = cms.int32(25),#this is old PAC pt scale.
-                                          charge = cms.int32(1),#can be 0(corresponds to q=-1) or 1(q=1)
+                                          charge = cms.int32(0),#can be 0(corresponds to q=1) or 1(q=0)
                                           omtf = cms.PSet(
                                               configFromXML = cms.bool(False),   
                                               patternsXMLFiles = cms.VPSet(                                       
@@ -134,7 +133,14 @@ process.omtfPatternMaker = cms.EDAnalyzer("OMTFPatternMaker",
                                           )
 )
 
-process.L1TMuonSeq = cms.Sequence(process.omtfPatternMaker)
+###Gen level filter configuration
+process.MuonEtaFilter = cms.EDFilter("SimTrackEtaFilter",
+                                minNumber = cms.uint32(1),
+                                src = cms.InputTag("g4SimHits"),
+                                cut = cms.string("momentum.eta<0.86 && momentum.eta>0.83 &&  momentum.pt>1")
+                                )
+
+process.L1TMuonSeq = cms.Sequence(process.MuonEtaFilter*process.omtfPatternMaker)
 
 process.L1TMuonPath = cms.Path(process.L1TMuonSeq)
 

--- a/L1Trigger/L1TMuonOverlap/test/runMuonOverlap.py
+++ b/L1Trigger/L1TMuonOverlap/test/runMuonOverlap.py
@@ -38,6 +38,8 @@ process.esProd = cms.EDAnalyzer("EventSetupRecordDataGetter",
 
 ####OMTF Emulator
 process.load('L1Trigger.L1TMuonOverlap.simMuonOverlapDigis_cfi')
+process.simOmtfDigis.dropRPCPrimitives = cms.bool(True)
+
 
 process.dumpED = cms.EDAnalyzer("EventContentAnalyzer")
 process.dumpES = cms.EDAnalyzer("PrintEventSetupContent")


### PR DESCRIPTION
…er station, while

  in MB3 we have only one roll, so 4 inputs per station)
- fix input ranges in hwToLogicLayers.xml
- create new patterns after fixin input number for RB3 and input ranges in hwToLogicLayers.xml
- still OMTF efficiency is about 1% lower than with old angle convections
- added method assigning quality 0 for candidates with bad hits patterns. WARNING: in this version the method is dummy, returns always true
- Golden Patterns for ref layer:  MB1, and measurement layers in MB1/2/3 suspicious shoulders in shapes, leading to constant offset in the meanPhi. This has to be understood.
